### PR TITLE
Fix versioning to allow up-to breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "~4.2.0"
+        "cakephp/cakephp": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.0 || ^9.3",
         "phpstan/phpstan": "^0.12.30",
-        "cakephp/cakephp-codesniffer": "~4.2.0"
+        "cakephp/cakephp-codesniffer": "^4.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package was requiring cakephp/cakephp: "~4.2.0" which prevented upgrading CakePHP to 4.3 and onwards. Now it will allow upgrades until (before) CakePHP 5, which will introduce breaking changes.